### PR TITLE
Implemented preview overlay while dragging a playable disk over a tower.

### DIFF
--- a/src/components/game/Disk.jsx
+++ b/src/components/game/Disk.jsx
@@ -37,7 +37,7 @@ class Disk extends Component {
       borderRadius: `calc((${Layout.DISK_HEIGHT}) / 1.5)`,
       border: "1px solid black",
       boxShadow: "inset 0 0 2px 0 black",
-      background: `rgba(244, ${green}, 36, 1)`
+      background: `rgb(244, ${green}, 36)`
     };
     return connectDragSource(<div style={diskStyle} />);
   }

--- a/src/components/game/Disk.jsx
+++ b/src/components/game/Disk.jsx
@@ -5,8 +5,8 @@ import ItemTypes from "../constants/ItemTypes";
 
 // draggable object
 const diskSource = {
-  beginDrag(props) {
-    return {};
+  beginDrag({ rank }) {
+    return { rank };
   },
 }
 
@@ -39,7 +39,7 @@ class Disk extends Component {
       boxShadow: "inset 0 0 2px 0 black",
       background: `rgb(244, ${green}, 36)`
     };
-    return connectDragSource(<div style={diskStyle} />);
+    return connectDragSource(<div style={diskStyle} rank={rank}></div>);
   }
 }
 

--- a/src/components/game/Tower.jsx
+++ b/src/components/game/Tower.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import Layout from "../constants/Layout";
 import Disk from "./Disk";
+import Overlay from "../util/Overlay";
 import { isValidDiskMove, moveDisk } from "../util/GamePlay";
 import { DropTarget } from "react-dnd";
 import ItemTypes from "../constants/ItemTypes";
@@ -22,15 +23,15 @@ const towerTarget = {
 
 const collect = (connect, monitor) => ({
   connectDropTarget: connect.dropTarget(),
-  highlighted: !!monitor.canDrop(),
-  hovered: !!monitor.isOver(),
+  canDrop: !!monitor.canDrop(),
+  isOver: !!monitor.isOver(),
   diskDragged: monitor.getItem(),
 });
 
 class Tower extends Component {
   render() {
-    const { disks, connectDropTarget, hovered } = this.props;
-    const background = hovered
+    const { disks, connectDropTarget, isOver, canDrop, diskDragged } = this.props;
+    const background = isOver
       ? `linear-gradient(
           to bottom,
           rgba(255, 204, 0, 1),
@@ -46,6 +47,8 @@ class Tower extends Component {
         )`;
     const borderRadius = `calc((${Layout.TOWER_WIDTH}) / 4)`;
     const towerStyle = {
+      position: "relative",
+      width: "100%",
       height: `calc(${Layout.TOWER_HEIGHT})`,
       borderStyle: "solid",
       borderWidth: "1px 1px 0px 1px",
@@ -58,6 +61,7 @@ class Tower extends Component {
 
     return connectDropTarget(
       <div style={towerStyle}>
+        {isOver && canDrop && <Overlay key={diskDragged.id} rank={diskDragged.id} />}
         {disks.map(disk => <Disk key={disk.id} rank={disk.id} />)}
       </div>
     );

--- a/src/components/game/Tower.jsx
+++ b/src/components/game/Tower.jsx
@@ -10,11 +10,16 @@ import ItemTypes from "../constants/ItemTypes";
 const towerTarget = {
   canDrop(props, monitor) {
     console.log("Detect if DISK can be validly dropped to TOWER.");
+    console.log(props); // contains disks from source tower
+    console.log(monitor); // monitors target
+    console.log(monitor.getItem()); // what is this empty object?
+    
     return isValidDiskMove();
   },
-  drop({disks}, monitor) {
-    console.log("Drop DISK, props:");
-    console.table(disks); // array of disks
+  drop(props, monitor) {
+    console.log("Drop DISK");
+    console.log(props);
+    console.log(monitor);
     moveDisk();
   },
   hover(props, monitor) {
@@ -24,8 +29,8 @@ const towerTarget = {
 
 const collect = (connect, monitor) => ({
   connectDropTarget: connect.dropTarget(),
-  canDrop: !!monitor.canDrop(),
-  isOver: !!monitor.isOver(),
+  canDrop: monitor.canDrop(),
+  isOver: monitor.isOver(),
   diskDragged: monitor.getItem(),
 });
 
@@ -54,16 +59,15 @@ class Tower extends Component {
       borderStyle: "solid",
       borderWidth: "1px 1px 0px 1px",
       borderRadius: `${borderRadius} ${borderRadius} 0 0`,
-      background: background,
       display: "grid",
       alignItems: "end",
-      alignContent: "end"
+      alignContent: "end",
+      background: background,
     };
-
+    
     return connectDropTarget(
       <div style={towerStyle}>
-        {/* {isOver && canDrop && <Overlay key={diskDragged.id} rank={diskDragged.id} />} */}
-        {isOver && canDrop && disks.push({ id: diskDragged.id })}
+        {isOver && canDrop && diskDragged && <Overlay rank={diskDragged.rank} />}
         {disks.map(disk => <Disk key={disk.id} rank={disk.id} />)}
       </div>
     );

--- a/src/components/game/Tower.jsx
+++ b/src/components/game/Tower.jsx
@@ -12,8 +12,9 @@ const towerTarget = {
     console.log("Detect if DISK can be validly dropped to TOWER.");
     return isValidDiskMove();
   },
-  drop(props, monitor) {
-    console.log("Drop DISK.");
+  drop({disks}, monitor) {
+    console.log("Drop DISK, props:");
+    console.table(disks); // array of disks
     moveDisk();
   },
   hover(props, monitor) {
@@ -61,7 +62,8 @@ class Tower extends Component {
 
     return connectDropTarget(
       <div style={towerStyle}>
-        {isOver && canDrop && <Overlay key={diskDragged.id} rank={diskDragged.id} />}
+        {/* {isOver && canDrop && <Overlay key={diskDragged.id} rank={diskDragged.id} />} */}
+        {isOver && canDrop && disks.push({ id: diskDragged.id })}
         {disks.map(disk => <Disk key={disk.id} rank={disk.id} />)}
       </div>
     );

--- a/src/components/util/Overlay.jsx
+++ b/src/components/util/Overlay.jsx
@@ -16,9 +16,10 @@ const Overlay = ({rank}) => {
       )`,
     width: `calc(${width})`,
     boxShadow: "inset 0 0 2px 0 black",
+    opacity: "0.75",
   }
   return (
-    <div style={overlayStyle} />
+    <div style={overlayStyle}></div>
   );
 };
 

--- a/src/components/util/Overlay.jsx
+++ b/src/components/util/Overlay.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import Layout from "../constants/Layout";
+
+const Overlay = ({rank}) => {
+  const width = `(${Layout.TOWER_WIDTH} + ${rank * Layout.DISK_WIDTH_FACTOR}vw)`;
+  const offset = `${rank * Layout.DISK_WIDTH_FACTOR / 2}vw`;
+  // hue of green: divide spectrum from yellow (200) to red (36)
+  const green = 200 - rank * ((200 - 36) / Layout.NUM_DISKS);
+  const overlayStyle ={
+    background: `rgb(244, ${green}, 36)`,
+    transform: `translateX(calc(-1 * (${offset})))`,
+    border: "1px solid black",
+    borderRadius: `calc((${Layout.DISK_HEIGHT}) / 1.5)`,
+    height: `calc(
+        ${Layout.DISK_HEIGHT} * ${Layout.MAX_TOTAL_DISKS} / ${Layout.NUM_DISKS}
+      )`,
+    width: `calc(${width})`,
+    boxShadow: "inset 0 0 2px 0 black",
+  }
+  return (
+    <div style={overlayStyle} />
+  );
+};
+
+export default Overlay;


### PR DESCRIPTION
Dragging a disk over any tower shows a slightly opaque preview of how that disk would like were it dropped onto the tower that it is hovering.

Next step: implement the disk dropping feature so that both the old and new towers reflect any changes.